### PR TITLE
[SUP-6349] use Original File images when Thumbnails don't exist

### DIFF
--- a/src/EventSubscriber/DiscoverOwnedThumbnailSubscriber.php
+++ b/src/EventSubscriber/DiscoverOwnedThumbnailSubscriber.php
@@ -48,6 +48,18 @@ class DiscoverOwnedThumbnailSubscriber extends AbstractImageDiscoverySubscriber 
       ->range(0, 1)
       ->execute();
 
+    // If there is no thumbnail, see if there is an Original File Image Media
+    // entity to style as a thumbnail instead.
+    if (empty($results)) {
+      $results = $this->mediaStorage->getQuery()
+        ->condition('field_media_of', $node->id())
+        ->condition('bundle', 'image')
+        ->condition('field_media_use.entity:taxonomy_term.field_external_uri.uri', 'http://pcdm.org/use#OriginalFile')
+        ->accessCheck()
+        ->range(0, 1)
+        ->execute();
+    }
+
     $event->addCacheTags(['media_list']);
 
     if ($results) {


### PR DESCRIPTION
If an object doesn't have Media with thumbnail `media use`, fallback to 'original file' Media when the 'original file' Media bundle is `image`. The extra query processing does not occur if a thumbnail is found.