### PR TITLE
SUP-6578: Add in additional cache contexts.

### DIFF
--- a/src/Controller/DeferredResolutionController.php
+++ b/src/Controller/DeferredResolutionController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dgi_image_discovery\Controller;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -71,7 +72,11 @@ class DeferredResolutionController implements ContainerInjectionInterface {
       $response->addCacheableDependency($metadata);
     }
 
-    return $response;
+    // Add some additional contexts representing this particular request.
+    $cache_meta = (new CacheableMetadata())
+      ->addCacheContexts(['route', 'url.path']);
+
+    return $response->addCacheableDependency($cache_meta);
 
   }
 


### PR DESCRIPTION
Had some other masking issues, such that this didn't get found previously; in particular:
- https://github.com/discoverygarden/enhanced_collection_pages/pull/24 and
- https://github.com/discoverygarden/digital_collections_utils/pull/11

avoid using the `user` cache context, which was making things uncacheable. Now that things _can_ be cached, can see that the values returned from the new "deferred resolution controller" can get mixed up between requests. 