### PR TITLE
DGI9-298: Allow for more redirecting responses in subrequests to be followed.

### DIFF
--- a/src/Plugin/dgi_image_discovery/url_generator/deferred/Subrequest.php
+++ b/src/Plugin/dgi_image_discovery/url_generator/deferred/Subrequest.php
@@ -54,7 +54,14 @@ class Subrequest extends DeferredResolutionPluginBase {
     $attempts = 3;
     while ($attempts-- > 0) {
       $current_request = $this->requestStack->getCurrentRequest();
-      $request = Request::create($generated_url->getGeneratedUrl());
+      if (!$current_request) {
+        throw new \LogicException('Unknown request.');
+      }
+      $request = Request::create(
+        $generated_url->getGeneratedUrl(),
+        cookies: $current_request->cookies->all(),
+        server: $current_request->server->all(),
+      );
       $request->setSession($current_request->getSession());
       $response = $this->httpKernel->handle($request, HttpKernelInterface::SUB_REQUEST);
       if ($response instanceof BinaryFileResponse) {

--- a/src/Plugin/dgi_image_discovery/url_generator/deferred/Subrequest.php
+++ b/src/Plugin/dgi_image_discovery/url_generator/deferred/Subrequest.php
@@ -63,6 +63,9 @@ class Subrequest extends DeferredResolutionPluginBase {
           ->setAutoLastModified()
           ->addCacheableDependency($generated_url);
       }
+      elseif ($response instanceof CacheableResponseInterface && ((int) ($response->getStatusCode() / 100)) === 3) {
+        return $response;
+      }
       elseif ($response->getStatusCode() === 503) {
         $after = $response->headers->get('Retry-After');
         if ($after === NULL) {
@@ -79,6 +82,7 @@ class Subrequest extends DeferredResolutionPluginBase {
           continue;
         }
       }
+
       throw $this->getExceptionFromResponse($response, $generated_url);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors by validating a current request before creating subrequests.
  * Subrequests now include cookies and server context for accurate session and redirect handling.
  * Properly handles cacheable 3xx responses to avoid unnecessary processing and improve redirect behavior.
  * Minor improvements to 503 response flow while preserving retry-after behavior, enhancing resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->