### PR TITLE
SEC-1647: Avoid error should the media not have a file.

### DIFF
--- a/src/Plugin/dgi_image_discovery/url_generator/UrlGenerationTrait.php
+++ b/src/Plugin/dgi_image_discovery/url_generator/UrlGenerationTrait.php
@@ -61,6 +61,9 @@ trait UrlGenerationTrait {
 
     $media_source = $media->getSource();
     $file_id = $media_source->getSourceFieldValue($media);
+    if (empty($file_id)) {
+      throw new CacheableNotFoundHttpException($generated_url, "No file ID for discovered media ({$media->id()}) for node ({$node->id()}).");
+    }
     /** @var \Drupal\file\FileInterface|null $image */
     $image = $this->getEntityTypeManager()->getStorage('file')->load($file_id);
     if (empty($image)) {


### PR DESCRIPTION
Something of an odd case... wanting to say that this seems like an issue with some invalid media entities kicking around which are missing a value pointing at an image? Indeed, found evidence of "image" media lacking any related file being referenced.

<details>

<summary>Stacktrace</summary>

```
 [error]  AssertionError: Cannot load the "file" entity with NULL ID. in assert() (line 261 of /var/www/html/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php) #0 /var/www/html/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(261): assert(false, 'Cannot load the...')
#1 /var/www/html/web/modules/contrib/dgi_image_discovery/src/Plugin/dgi_image_discovery/url_generator/UrlGenerationTrait.php(65): Drupal\Core\Entity\EntityStorageBase->load(NULL)
#2 /var/www/html/web/modules/contrib/dgi_image_discovery/src/Plugin/dgi_image_discovery/url_generator/PreGenerated.php(50): Drupal\dgi_image_discovery\Plugin\dgi_image_discovery\url_generator\PreGenerated->getGeneratedUrl(Object(Drupal\node\Entity\Node), Object(Drupal\dgi_i8_helper\Entity\ImageStyle))
#3 /var/www/html/web/modules/contrib/dgi_image_discovery/src/Plugin/search_api/processor/DgiImageDiscovery.php(130): Drupal\dgi_image_discovery\Plugin\dgi_image_discovery\url_generator\PreGenerated->generate(Object(Drupal\node\Entity\Node), Object(Drupal\dgi_i8_helper\Entity\ImageStyle))
#4 /var/www/html/web/modules/contrib/search_api/src/Item/Item.php(289): Drupal\dgi_image_discovery\Plugin\search_api\processor\DgiImageDiscovery->addFieldValues(Object(Drupal\search_api\Item\Item))
#5 /var/www/html/web/modules/contrib/search_api/src/Entity/Index.php(1026): Drupal\search_api\Item\Item->getFields()
[... of into search_api_fast / command bootstrap; snipping ...]
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during image URL generation: when a media item lacks a file reference, the system now returns a proper not-found response instead of generating an invalid link.
  * Prevents broken image URLs and provides clearer feedback when an image asset is unavailable, while leaving normal image delivery unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->