### PR TITLE
Add category for DGI image discovery field type

### DIFF
--- a/dgi_image_discovery.field_type_categories.yml
+++ b/dgi_image_discovery.field_type_categories.yml
@@ -1,0 +1,4 @@
+dgi_image_discovery:
+  label: "DGI Image Discovery"
+  description: "An image relevant to the given node."
+  weight: 100

--- a/dgi_image_discovery.info.yml
+++ b/dgi_image_discovery.info.yml
@@ -2,7 +2,7 @@ name: DGI Image Discovery
 description: Repository object augmentation.
 package: DGI Helpers
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 dependencies:
   - drupal:image
   - islandora:islandora

--- a/src/Plugin/Field/FieldType/DIDImageItem.php
+++ b/src/Plugin/Field/FieldType/DIDImageItem.php
@@ -18,6 +18,7 @@ use Drupal\dgi_image_discovery\ImageDiscoveryInterface;
  *   description = @Translation("An image relevant to the given node."),
  *   default_formatter = "media_thumbnail",
  *   constraints = {"ReferenceAccess" = {}},
+ *   category = "dgi_image_discovery",
  *   list_class = "\Drupal\dgi_image_discovery\DIDImageItemList",
  * )
  */


### PR DESCRIPTION
While creating fields, the DGI Image Discovery field appears as Taxonomy Term. 

Re: https://islandora.slack.com/archives/CM5PPAV28/p1756247387293879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a new field type category, “DGI Image Discovery,” with a label and description to improve admin selection and organization.
  - Related image fields are grouped under this category and set to appear lower in lists for consistent placement.

- Chores
  - Updated minimum platform core requirement to 10.2 (affects compatibility/upgrade planning).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->