### PR TITLE
Prevent other field additions.

### DIFF
--- a/src/Plugin/Field/FieldType/DIDImageItem.php
+++ b/src/Plugin/Field/FieldType/DIDImageItem.php
@@ -19,6 +19,7 @@ use Drupal\dgi_image_discovery\ImageDiscoveryInterface;
  *   default_formatter = "media_thumbnail",
  *   constraints = {"ReferenceAccess" = {}},
  *   list_class = "\Drupal\dgi_image_discovery\DIDImageItemList",
+ *   no_ui = TRUE,
  * )
  */
 class DIDImageItem extends EntityReferenceItem implements RefinableCacheableDependencyInterface {


### PR DESCRIPTION
Was leading to attempting to create other references for the various other entity types, which does not really make sense with this computed field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the DID Image field type from the admin UI; it no longer appears when adding or configuring fields.
  - Existing instances continue to function with no content changes, migrations, or API updates required.
  - Streamlines configuration screens without affecting current data, permissions, displays, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->