### PR TITLE
SEC-2766: Add feature flag around the "original file" fallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Under "Manage display" for a content type, you can enable the pseudo-field
 
 | Name | Default | Description |
 | --- | --- | --- |
-| `DGI_IMAGE_DISCOVERY__FALLBACK_TO_ORIGINAL_FILE` | `"false"` | Boolean toggle to allow the use of "original file" media in should a "thumbnail" be absent. |
+| `DGI_IMAGE_DISCOVERY__FALLBACK_TO_ORIGINAL_FILE` | `"false"` | Boolean toggle to allow the use of "original file" media should a "thumbnail" be absent. |
 | `DGI_IMAGE_DISCOVERY_DEFERRED_PLUGIN` | `"subrequest"` | See [Deferral mechanism](#deferral-mechanism) docs. |
 
 ## Troubleshooting/Issues

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ When configuring a content view, add and configure the virtual field
 Under "Manage display" for a content type, you can enable the pseudo-field
 "DGI Image Discovery Discovered Image".
 
+### Environment Variables
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `DGI_IMAGE_DISCOVERY__FALLBACK_TO_ORIGINAL_FILE` | `"false"` | Boolean toggle to allow the use of "original file" media in should a "thumbnail" be absent. |
+| `DGI_IMAGE_DISCOVERY_DEFERRED_PLUGIN` | `"subrequest"` | See [Deferral mechanism](#deferral-mechanism) docs. |
+
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Contact

--- a/src/EventSubscriber/DiscoverOwnedThumbnailSubscriber.php
+++ b/src/EventSubscriber/DiscoverOwnedThumbnailSubscriber.php
@@ -22,12 +22,23 @@ class DiscoverOwnedThumbnailSubscriber extends AbstractImageDiscoverySubscriber 
   protected EntityStorageInterface $mediaStorage;
 
   /**
+   * Flag to allow falling back to original file if thumbnail is absent.
+   *
+   * @var bool
+   */
+  protected bool $fallbackToOriginalFile = FALSE;
+
+  /**
    * Constructor.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
   ) {
     $this->mediaStorage = $entity_type_manager->getStorage('media');
+    $this->fallbackToOriginalFile = filter_var(
+      getenv('DGI_IMAGE_DISCOVERY__FALLBACK_TO_ORIGINAL_FILE') ?: 'false',
+      FILTER_VALIDATE_BOOLEAN,
+    );
   }
 
   /**
@@ -49,7 +60,7 @@ class DiscoverOwnedThumbnailSubscriber extends AbstractImageDiscoverySubscriber 
 
     // If there is no thumbnail, see if there is an Original File Image Media
     // entity to style as a thumbnail instead.
-    if (empty($results)) {
+    if (empty($results) && $this->fallbackToOriginalFile) {
       $results = $this->mediaStorage->getQuery()
         ->condition('field_media_of', $node->id())
         ->condition('bundle', 'image')


### PR DESCRIPTION
Also, make it such that this fallback behavior is not the default.

Originally implemented back in #18, this behavior can break sites where original files are remotely hosted, and encountering a page with many nodes that do not have a related thumbnail for whatever reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional fallback to use original files when thumbnails are unavailable, controlled by a new environment variable.
  * Configurable deferred URL dereferencing mechanism via a new environment variable.

* **Documentation**
  * README updated with an "Environment Variables" section documenting the two new configuration options and their defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->